### PR TITLE
delete lineitem debugged

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,7 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
-
+            order_product.delete()
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Added single line invoking `.delete()` within the lineitem view (`lineitem.py`)

## Requests / Responses

DELETE `/lineitems/x` should return empty JSON object if there is lineitem associated with user and pk `x`
Status code: HTTP/1.1 204 No Content


## Testing

Description of how to test code...

- [ ] Pull from branch `al-ticket20-debug_remove_item_from_cart`
- [ ] Reseed the database
- [ ] Run GET fetch call on `/profile/cart` and select the pk of a `lineitem` object
- [ ] Test that running DELETE on `/lineitems/pk` returns an empty object and 204 response
- [ ] Run GET on `/profile/cart` again and verify that the lineitem object with selected pk has been removed from db


## Related Issues

- Fixes #20 