### PR TITLE
paymenttypes now displays only accounts associated with current user

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,5 +1,6 @@
 """View module for handling requests about customer payment types"""
 from django.http import HttpResponseServerError
+from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
@@ -34,8 +35,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
@@ -79,13 +80,16 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
-
-        serializer = PaymentSerializer(
-            payment_types, many=True, context={'request': request})
-        return Response(serializer.data)
+        if customer:
+            try:
+                payment_types = Payment.objects.filter(customer=customer.pk)
+                serializer = PaymentSerializer(
+                    payment_types, many=True, context={'request': request})
+                return Response(serializer.data)
+            except Payment.DoesNotExist as ex:
+                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        else:
+            return Response({'message': 'Authentication Error'}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Changes

Changes made to `paymenttype.py`:
- Switched key-value pairs around on `create` paymenttype view to fix false expiry date issue ( #19 )
- Modified the list function to check current user credentials, then sort payment table according to customer_id, returning only those entries associated with the current user ( #18 )

## Requests / Responses

**Request**

POST `http://localhost:8000/paymenttypes` Creates a new payment type

```json
{
    "merchant_name": "Amex",
    "account_number": "000550000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 CREATED

```json
{
    "id": x,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Amex",
    "account_number": "000550000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```
Confirm that the date info matches up!

Then:

GET on `http://localhost:8000/paymenttypes`

RESPONSE:
```json
[{
    "id": x,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Amex",
    "account_number": "000550000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}]
```

## Testing

Description of how to test code...

- [ ] Pull from local branch and run migrations
- [ ] Use Postman to test POST and GET fetch calls to Payments table
- [ ] Confirm that the results match the specifications above

## Related Issues

- Fixes #19 
- Fixes #18 