### PR TITLE
ticket complete

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,6 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -273,6 +274,13 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+        
+        if min_price is not None:
+            def price_filter(product):
+                if product.price >= int(min_price):
+                    return True
+                return False
+            products = filter(price_filter, products)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Added ability to handle `min_price` query string on GET calls to `/products`

## Requests / Responses

GET `http://localhost:8000/products?min_price=150` retrieves products that are $150+. (Works with other integers as well!)

## Testing

- [ ] Pull from branch to local machine
- [ ] Reseed database
- [ ] Confirm that, when running GET call to `http://localhost:8000/products?min_price=150` in Postman, an array of product objects that are only $150 and over is returned.


## Related Issues

- Fixes #17 