### PR TITLE
location query param supported

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-Description of PR that completes issue here...
-
 ## Changes
 
 - Item 1
@@ -8,45 +6,30 @@ Description of PR that completes issue here...
 
 ## Requests / Responses
 
-If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.
-
 **Request**
 
 POST `/products` Creates a new product
 
 ```json
-{
-    "title": "Kite",
-    "product_type_id": 1,
-    "description": "Red. It flies high.",
-    "quantity": 5
-}
+
 ```
 
 **Response**
 
-HTTP/1.1 201 OK
+HTTP/1.1 200 OK
 
 ```json
-{
-    "id": 54,
-    "title": "Kite",
-    "product_type_id": 1,
-    "description": "Red. It flies high.",
-    "quantity": 5
-}
+
 ```
 
 ## Testing
 
 Description of how to test code...
 
-- [ ] Run migrations
-- [ ] Run test suite
-- [ ] Seed database
+- [ ] Pull locally from this branch and re-seed the db
+- [ ] 
 
 
 ## Related Issues
 
-- Fixes #85
-- Fixes #22
+- Fixes #

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -284,7 +284,7 @@ class Products(ViewSet):
             products = filter(price_filter, products)
         
         if location is not None:
-            products = Product.objects.filter(location__contains=location)
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -251,6 +251,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -281,6 +282,9 @@ class Products(ViewSet):
                     return True
                 return False
             products = filter(price_filter, products)
+        
+        if location is not None:
+            products = Product.objects.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Added code to `/views/products.py` to support `/products?locations=x` query string parameter

## Requests / Responses

**Sample Request**

GET `http://localhost:8000/products?location=ville` to filter products by location

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 10,
        "name": "Land Cruiser",
        "price": 1768.97,
        "number_sold": 0,
        "description": "2008 Toyota",
        "quantity": 3,
        "created_date": "2019-10-07",
        "location": "Niverville",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] Pull from branch and re-seed db
- [ ] Run GET fetch call on `http://localhost:8000/products?location=ville`
- [ ] Confirm that results match above
- [ ] Run tests on other location strings


## Related Issues

- Fixes #14 