### PR TITLE
Rating Product / Test for Prod Rating

### DIFF
--- a/tests/product.py
+++ b/tests/product.py
@@ -98,3 +98,16 @@ class ProductTests(APITestCase):
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.
+    def test_rate_product(self):
+        self.test_create_product()
+        url = "/products/1/rate"
+        data = {
+            "rating": 9
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        url = "/products/1"
+        response = self.client.get(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        json_response = json.loads(response.content)
+        self.assertEqual(json_response["average_rating"], 9)


### PR DESCRIPTION
## Changes

- Added `rate` custom action to Product viewset 
- Added `test_rate_product` function to Product tests

## Requests / Responses

**Request**

POST `/products/10/rate` Adds a ProductRating to db or updates existing entry

```json
{
"rating": 9
}
```

**Response**

HTTP/1.1 201 CREATED (new entry) or 204 NO_CONTENT (update) + Message

## Testing

Description of how to test code...

- [ ] Pull locally from this branch, run/install virtual env, open Postman
- [ ] In Postman, test that you can add a rating to a product (see above)
- [ ] Then, in virtual env, run `python3 manage.py test tests -v 1` and verify that the codebase passes the new test suite, including the test that creates a new rating


## Related Issues

- Fixes #7 