### PR TITLE
Test of deleting payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -57,6 +57,8 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+        except Payment.DoesNotExist:
+            return Response({'message': 'Payment type with this id does not exist'}, status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -41,3 +41,22 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today()
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        url = '/paymenttypes/1'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+


### PR DESCRIPTION
## Changes

- Added test of deleting payment type to `tests/payments.py`
- Modified the return on the Retrieve method in `views/paymenttype.py` to specify when entry is not found

## Testing

Description of how to test code...

- [ ] Pull locally from this branch, re-install virtual env
- [ ] Run `python3 manage.py test tests -v 1` and verify that the test of deleting payment types runs


## Related Issues

- Fixes #9 