### PR TITLE
Added test that line item added to open order

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -82,3 +82,16 @@ class OrderTests(APITestCase):
     # TODO: Complete order by adding payment type
 
     # TODO: New line item is not added to closed order
+    def test_line_item_added_to_open_order(self):
+        # Add product to cart
+        url = "/cart"
+        data = { "product_id": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify product was added to open order (i.e. an order with a payment type of None)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(json_response["payment_type"])


### PR DESCRIPTION
## Changes

- Added test that line item is added to open order (one with `'payment_type' = None`) in `tests/order.py`

## Testing

Description of how to test code...

- [ ] Pull locally from this branch and re-install pipenv
- [ ] Run test suite and verify that the code passes test `test_line_item_added_to_open_order`


## Related Issues

- Fixes #10 